### PR TITLE
Add driver options for garage-data volume

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -9,9 +9,15 @@ services:
       - LOG_LEVEL=debug
       - LOG_FORMAT=text
     
-    # Example: Mount local source code for development
+    # Example: Mount data directory, which must exist,
+		#   mkdir -p ./data && chown 1000:1000 ./data
     # volumes:
-    #   - ./:/app/src
+		#		garage-data:
+    #	    driver: local
+		# 	  driver_opts:
+		#		    o: bind
+		#		    type: none
+		#		    device: ./data
     
     # Example: Override ports
     # ports:


### PR DESCRIPTION
## Problem

When using the project with a local docker compose, the db volume is not mounted to a local place in the project filesystem making it difficult to backup the database.

## Solution

Add details for local volume based on [help from StackOverflow](https://stackoverflow.com/a/55952189). The solution was tested locally.