### PR TITLE
feat: add fuel records data layer (migration, model, repository)

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -28,6 +28,8 @@ The following migrations are currently in place:
 3. **000003_create_maintenance_records_table**: Creates the `maintenance_records` table with foreign key to vehicles
 4. **000004_add_display_name_to_vehicles**: Adds `display_name` column to vehicles table
 5. **000005_add_custom_service_type_to_maintenance**: Adds `custom_service_type` column to maintenance_records table for the "Other" service type option
+6. **000006_create_vehicle_metrics_table**: Creates the `vehicle_metrics` table for aggregated vehicle statistics
+7. **000007_create_fuel_records_table**: Creates the `fuel_records` table with foreign key to vehicles, supporting fuel fill-up tracking
 
 ### Schema Evolution
 
@@ -197,6 +199,7 @@ migrate -database "sqlite3://./data/go-garage.db" -path ./migrations up
 ### Scenario 4: Rollback in Production
 
 1. **Backup Database First** (Critical!)
+
    ```bash
    make db-backup
    # or
@@ -204,23 +207,27 @@ migrate -database "sqlite3://./data/go-garage.db" -path ./migrations up
    ```
 
 2. **Stop the Application**
+
    ```bash
    # Stop the running server
    pkill -f go-garage
    ```
 
 3. **Rollback the Migration**
+
    ```bash
    # Using migrate CLI
    migrate -database "sqlite3://./data/go-garage.db" -path ./migrations down 1
    ```
 
 4. **Verify the Rollback**
+
    ```bash
    migrate -database "sqlite3://./data/go-garage.db" -path ./migrations version
    ```
 
 5. **Restart with Previous Application Version**
+
    ```bash
    # Deploy and start previous version
    git checkout <previous-version>
@@ -248,6 +255,7 @@ touch migrations/000004_add_fuel_records_table.down.sql
 ```
 
 **Up Migration** (`000004_add_fuel_records_table.up.sql`):
+
 ```sql
 CREATE TABLE IF NOT EXISTS fuel_records (
     id TEXT PRIMARY KEY,
@@ -269,6 +277,7 @@ CREATE INDEX idx_fuel_date ON fuel_records(date);
 ```
 
 **Down Migration** (`000004_add_fuel_records_table.down.sql`):
+
 ```sql
 DROP INDEX IF EXISTS idx_fuel_date;
 DROP INDEX IF EXISTS idx_fuel_vehicle_id;
@@ -282,6 +291,7 @@ DROP TABLE IF EXISTS fuel_records;
 **Cause**: A migration was interrupted or failed midway.
 
 **Solution**:
+
 1. Check which migration is dirty: `migrate version`
 2. Manually fix the database state or use `migrate force <version>`
 3. Re-run migrations

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -82,6 +82,43 @@ Go-Garage uses SQLite as its database. The schema is managed through versioned m
 │   idx_maintenance_service_date           │
 │         (service_date)                   │
 └─────────────────────────────────────────┘
+
+                    │ (from vehicles)
+                    │ 1:N
+                    ▼
+┌─────────────────────────────────────────┐
+│            fuel_records                  │
+├─────────────────────────────────────────┤
+│ id                    TEXT    PK         │
+│ vehicle_id            TEXT    FK NOT NULL│
+│ fill_date             DATE    NOT NULL   │
+│ mileage               INTEGER NOT NULL   │
+│ volume                REAL    NOT NULL   │
+│ fuel_type             TEXT    NOT NULL   │
+│ partial_fill          INTEGER NOT NULL   │
+│ price_per_unit        REAL               │
+│ octane_rating         INTEGER            │
+│ location              TEXT               │
+│ brand                 TEXT               │
+│ notes                 TEXT               │
+│ city_driving_percentage INTEGER          │
+│ vehicle_reported_mpg  REAL               │
+│ created_at            DATETIME NOT NULL  │
+│ updated_at            DATETIME NOT NULL  │
+├─────────────────────────────────────────┤
+│ Constraints:                             │
+│   CHECK(fuel_type IN ('gasoline',       │
+│         'diesel','e85'))                 │
+│   CHECK(city_driving_percentage IS NULL  │
+│     OR (>= 0 AND <= 100))              │
+│   FOREIGN KEY (vehicle_id) REFERENCES    │
+│         vehicles(id) ON DELETE CASCADE   │
+│ Indexes:                                 │
+│   idx_fuel_records_vehicle_id            │
+│         (vehicle_id)                     │
+│   idx_fuel_records_fill_date             │
+│         (fill_date)                      │
+└─────────────────────────────────────────┘
 ```
 
 ## Table Descriptions
@@ -103,6 +140,7 @@ The `users` table stores user account information and authentication credentials
 | `last_login_at` | DATETIME | | Timestamp of last successful login |
 
 **Indexes:**
+
 - `idx_users_email` - Speeds up email lookups for authentication
 - `idx_users_username` - Speeds up username lookups for authentication
 
@@ -130,10 +168,12 @@ The `vehicles` table stores information about vehicles owned by users.
 | `updated_at` | DATETIME | NOT NULL | Timestamp of last update |
 
 **Constraints:**
+
 - Foreign key to `users(id)` with `ON DELETE CASCADE`
 - Check constraint: `status IN ('active', 'sold', 'scrapped')`
 
 **Indexes:**
+
 - `idx_vehicles_user_id` - Speeds up queries for a user's vehicles
 - `idx_vehicles_vin` - Speeds up VIN lookups
 - `idx_vehicles_status` - Speeds up filtering by status
@@ -157,11 +197,47 @@ The `maintenance_records` table stores service and maintenance history for vehic
 | `updated_at` | DATETIME | NOT NULL | Timestamp of last update |
 
 **Constraints:**
+
 - Foreign key to `vehicles(id)` with `ON DELETE CASCADE`
 
 **Indexes:**
+
 - `idx_maintenance_vehicle_id` - Speeds up queries for a vehicle's maintenance history
 - `idx_maintenance_service_date` - Speeds up date-based queries and sorting
+
+### fuel_records
+
+The `fuel_records` table stores fuel fill-up records for vehicles.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | TEXT | PRIMARY KEY | UUID identifier for the record |
+| `vehicle_id` | TEXT | FK, NOT NULL | Reference to the vehicle |
+| `fill_date` | DATE | NOT NULL | Date of the fuel fill-up |
+| `mileage` | INTEGER | NOT NULL | Odometer reading at fill-up |
+| `volume` | REAL | NOT NULL | Volume of fuel in gallons |
+| `fuel_type` | TEXT | NOT NULL, CHECK | Fuel type: 'gasoline', 'diesel', or 'e85' |
+| `partial_fill` | INTEGER | NOT NULL, DEFAULT 0 | Whether this was a partial fill (0=no, 1=yes) |
+| `price_per_unit` | REAL | | Price per gallon |
+| `octane_rating` | INTEGER | | Fuel octane rating |
+| `location` | TEXT | | Location of the fuel station |
+| `brand` | TEXT | | Fuel brand name |
+| `notes` | TEXT | | Additional notes |
+| `city_driving_percentage` | INTEGER | CHECK 0-100 | Percentage of city driving since last fill-up |
+| `vehicle_reported_mpg` | REAL | | MPG reported by vehicle computer |
+| `created_at` | DATETIME | NOT NULL | Timestamp of record creation |
+| `updated_at` | DATETIME | NOT NULL | Timestamp of last update |
+
+**Constraints:**
+
+- Foreign key to `vehicles(id)` with `ON DELETE CASCADE`
+- Check constraint: `fuel_type IN ('gasoline', 'diesel', 'e85')`
+- Check constraint: `city_driving_percentage IS NULL OR (>= 0 AND <= 100)`
+
+**Indexes:**
+
+- `idx_fuel_records_vehicle_id` - Speeds up queries for a vehicle's fuel records
+- `idx_fuel_records_fill_date` - Speeds up date-based queries and sorting
 
 ## Relationships
 
@@ -181,6 +257,15 @@ A vehicle can have multiple maintenance records. When a vehicle is deleted, all 
 ```sql
 -- Example: Get all maintenance for a vehicle
 SELECT * FROM maintenance_records WHERE vehicle_id = ? ORDER BY service_date DESC;
+```
+
+### Vehicle → Fuel Records (One-to-Many)
+
+A vehicle can have multiple fuel records. When a vehicle is deleted, all its fuel records are automatically deleted due to `ON DELETE CASCADE`.
+
+```sql
+-- Example: Get all fuel records for a vehicle
+SELECT * FROM fuel_records WHERE vehicle_id = ? ORDER BY fill_date DESC;
 ```
 
 ## Data Types
@@ -210,6 +295,10 @@ The schema is managed through versioned migrations:
 | 000001 | create_users_table | Creates users table with indexes |
 | 000002 | create_vehicles_table | Creates vehicles table with FK to users |
 | 000003 | create_maintenance_records_table | Creates maintenance_records table with FK to vehicles |
+| 000004 | add_display_name_to_vehicles | Adds display_name column to vehicles |
+| 000005 | add_custom_service_type_to_maintenance | Adds custom_service_type column to maintenance_records |
+| 000006 | create_vehicle_metrics_table | Creates vehicle_metrics table for aggregated stats |
+| 000007 | create_fuel_records_table | Creates fuel_records table with FK to vehicles |
 
 For migration management details, see [Database Migrations Guide](./database-migrations.md).
 
@@ -218,6 +307,7 @@ For migration management details, see [Database Migrations Guide](./database-mig
 ### SQLite Choice
 
 SQLite was chosen for:
+
 - **Simplicity**: No separate database server required
 - **Portability**: Single file database, easy to backup
 - **Performance**: Excellent read performance for small-to-medium datasets
@@ -226,6 +316,7 @@ SQLite was chosen for:
 ### UUID Primary Keys
 
 UUIDs are used instead of auto-increment integers for:
+
 - **Distributed Generation**: IDs can be generated in application code
 - **No Collisions**: Safe for distributed systems
 - **Security**: IDs are not sequential/predictable
@@ -233,6 +324,7 @@ UUIDs are used instead of auto-increment integers for:
 ### Cascade Deletes
 
 `ON DELETE CASCADE` is used to:
+
 - **Maintain Integrity**: Automatically clean up child records
 - **Simplify Code**: No need for manual cleanup logic
 - **Prevent Orphans**: No orphaned vehicles or maintenance records
@@ -240,6 +332,7 @@ UUIDs are used instead of auto-increment integers for:
 ### Index Strategy
 
 Indexes are added for:
+
 - **Foreign Keys**: `user_id`, `vehicle_id` for join performance
 - **Unique Lookups**: `email`, `username`, `vin` for authentication and search
 - **Filtering**: `status`, `service_date` for common filter operations
@@ -248,8 +341,7 @@ Indexes are added for:
 
 ### Planned Tables
 
-1. **fuel_records** - Track fuel purchases and consumption
-2. **reminders** - Service reminders and scheduled maintenance
+1. **reminders** - Service reminders and scheduled maintenance
 
 ### Potential Improvements
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -17,6 +17,10 @@ internal/repositories/
 ├── maintenance.go           # MaintenanceRepository interface
 ├── maintenance_sqlite.go    # SQLite implementation
 ├── maintenance_sqlite_test.go # Unit tests
+├── fuel.go                  # FuelRepository interface
+├── fuel_sqlite.go           # SQLite implementation (write ops + helpers)
+├── fuel_sqlite_read.go      # SQLite implementation (read ops)
+├── fuel_sqlite_test.go      # Unit tests
 └── testutils_test.go        # Shared test utilities
 ```
 
@@ -34,6 +38,7 @@ type PaginationParams struct {
 ```
 
 **Example Usage:**
+
 ```go
 // Get first 10 vehicles
 pagination := PaginationParams{Limit: 10, Offset: 0}
@@ -71,17 +76,21 @@ Create(ctx context.Context, user *models.User) error
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `user`: User object to create. ID will be generated if empty.
 
 **Returns:**
+
 - `error`: `nil` on success, `*models.ValidationError` if validation fails, `*models.DuplicateError` if username or email exists
 
 **Side Effects:**
+
 - Sets `user.ID` if empty (generates UUID)
 - Sets `user.CreatedAt` and `user.UpdatedAt` to current time
 
 **Example:**
+
 ```go
 user := &models.User{
     Username:     "johndoe",
@@ -110,14 +119,17 @@ FindByID(ctx context.Context, id string) (*models.User, error)
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `id`: UUID of the user
 
 **Returns:**
+
 - `*models.User`: User object if found
 - `error`: `*models.NotFoundError` if user doesn't exist
 
 **Example:**
+
 ```go
 user, err := repo.FindByID(ctx, "550e8400-e29b-41d4-a716-446655440000")
 if err != nil {
@@ -138,10 +150,12 @@ FindByEmail(ctx context.Context, email string) (*models.User, error)
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `email`: Email address to search for
 
 **Returns:**
+
 - `*models.User`: User object if found
 - `error`: `*models.NotFoundError` if user doesn't exist
 
@@ -156,10 +170,12 @@ FindByUsername(ctx context.Context, username string) (*models.User, error)
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `username`: Username to search for
 
 **Returns:**
+
 - `*models.User`: User object if found
 - `error`: `*models.NotFoundError` if user doesn't exist
 
@@ -174,16 +190,20 @@ Update(ctx context.Context, user *models.User) error
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `user`: User object with updated fields. ID must be set.
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if user doesn't exist, `*models.ValidationError` if validation fails, `*models.DuplicateError` if email/username conflicts
 
 **Side Effects:**
+
 - Updates `user.UpdatedAt` to current time
 
 **Example:**
+
 ```go
 user.FirstName = "Jane"
 user.LastName = "Smith"
@@ -199,13 +219,16 @@ Delete(ctx context.Context, id string) error
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `id`: UUID of the user to delete
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if user doesn't exist
 
 **Side Effects:**
+
 - Cascading delete of all user's vehicles and their maintenance records
 
 #### UpdateLastLogin
@@ -217,10 +240,12 @@ UpdateLastLogin(ctx context.Context, id string) error
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `id`: UUID of the user
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if user doesn't exist
 
 **Use Case:** Called after successful authentication
@@ -267,19 +292,23 @@ Create(ctx context.Context, vehicle *models.Vehicle) error
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `vehicle`: Vehicle object to create. ID will be generated if empty.
 
 **Returns:**
+
 - `error`: `*models.ValidationError` if validation fails, `*models.DuplicateError` if VIN exists
 
 **Validation:**
+
 - VIN must be exactly 17 characters (excluding I, O, Q)
 - Year must be between 1900 and current year + 1
 - UserID must reference an existing user
 - Make, Model, and Status are required
 
 **Example:**
+
 ```go
 vehicle := &models.Vehicle{
     UserID: userID,
@@ -301,6 +330,7 @@ FindByID(ctx context.Context, id string) (*models.Vehicle, error)
 ```
 
 **Returns:**
+
 - `*models.Vehicle`: Vehicle object if found
 - `error`: `*models.NotFoundError` if vehicle doesn't exist
 
@@ -313,14 +343,17 @@ FindByUserID(ctx context.Context, userID string) ([]*models.Vehicle, error)
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `userID`: UUID of the user
 
 **Returns:**
+
 - `[]*models.Vehicle`: Slice of vehicles (empty if none found)
 - `error`: Database errors only (not NotFoundError for empty results)
 
 **Example:**
+
 ```go
 vehicles, err := repo.FindByUserID(ctx, userID)
 if err != nil {
@@ -340,10 +373,12 @@ FindByVIN(ctx context.Context, vin string) (*models.Vehicle, error)
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `vin`: Vehicle Identification Number
 
 **Returns:**
+
 - `*models.Vehicle`: Vehicle object if found
 - `error`: `*models.NotFoundError` if vehicle doesn't exist
 
@@ -358,6 +393,7 @@ Update(ctx context.Context, vehicle *models.Vehicle) error
 ```
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if vehicle doesn't exist, `*models.ValidationError` if validation fails, `*models.DuplicateError` if VIN conflicts
 
 #### Delete
@@ -369,9 +405,11 @@ Delete(ctx context.Context, id string) error
 ```
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if vehicle doesn't exist
 
 **Side Effects:**
+
 - Cascading delete of all vehicle's maintenance records
 
 #### List
@@ -383,15 +421,18 @@ List(ctx context.Context, filters VehicleFilters, pagination PaginationParams) (
 ```
 
 **Parameters:**
+
 - `ctx`: Context for cancellation and timeouts
 - `filters`: Optional filters (nil values are ignored)
 - `pagination`: Limit and offset for results
 
 **Returns:**
+
 - `[]*models.Vehicle`: Slice of matching vehicles
 - `error`: Database errors only
 
 **Example:**
+
 ```go
 // Get all active vehicles, page 1
 status := models.VehicleStatusActive
@@ -438,12 +479,14 @@ Create(ctx context.Context, record *models.MaintenanceRecord) error
 ```
 
 **Validation:**
+
 - VehicleID must reference an existing vehicle
 - ServiceType is required
 - ServiceDate is required and cannot be in the future
 - Cost must be non-negative if provided
 
 **Example:**
+
 ```go
 record := &models.MaintenanceRecord{
     VehicleID:   vehicleID,
@@ -463,6 +506,7 @@ FindByID(ctx context.Context, id string) (*models.MaintenanceRecord, error)
 ```
 
 **Returns:**
+
 - `*models.MaintenanceRecord`: Record if found
 - `error`: `*models.NotFoundError` if record doesn't exist
 
@@ -475,6 +519,7 @@ FindByVehicleID(ctx context.Context, vehicleID string) ([]*models.MaintenanceRec
 ```
 
 **Returns:**
+
 - `[]*models.MaintenanceRecord`: Slice of records (empty if none found)
 - `error`: Database errors only
 
@@ -489,6 +534,7 @@ Update(ctx context.Context, record *models.MaintenanceRecord) error
 ```
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if record doesn't exist, `*models.ValidationError` if validation fails
 
 #### Delete
@@ -500,6 +546,7 @@ Delete(ctx context.Context, id string) error
 ```
 
 **Returns:**
+
 - `error`: `*models.NotFoundError` if record doesn't exist
 
 #### List
@@ -511,12 +558,141 @@ List(ctx context.Context, filters MaintenanceFilters, pagination PaginationParam
 ```
 
 **Example:**
+
 ```go
 // Get all oil changes
 serviceType := "Oil Change"
 filters := MaintenanceFilters{ServiceType: &serviceType}
 pagination := PaginationParams{Limit: 100, Offset: 0}
 records, err := repo.List(ctx, filters, pagination)
+```
+
+---
+
+## FuelRepository
+
+Interface for fuel record data access operations.
+
+### Filter Types
+
+```go
+type FuelFilters struct {
+    VehicleID *string  // Filter by vehicle
+    FuelType  *string  // Filter by fuel type (gasoline, diesel, e85)
+}
+```
+
+### Interface Definition
+
+```go
+type FuelRepository interface {
+    Create(ctx context.Context, record *models.FuelRecord) error
+    FindByID(ctx context.Context, id string) (*models.FuelRecord, error)
+    FindByVehicleID(ctx context.Context, vehicleID string) ([]*models.FuelRecord, error)
+    Update(ctx context.Context, record *models.FuelRecord) error
+    Delete(ctx context.Context, id string) error
+    List(ctx context.Context, filters FuelFilters, pagination PaginationParams) ([]*models.FuelRecord, error)
+    Count(ctx context.Context, filters FuelFilters) (int, error)
+}
+```
+
+### Method Details
+
+#### Create
+
+Inserts a new fuel record into the database.
+
+```go
+Create(ctx context.Context, record *models.FuelRecord) error
+```
+
+**Validation:**
+
+- VehicleID must reference an existing vehicle
+- FillDate is required and cannot be in the future
+- Mileage must be greater than zero
+- Volume must be greater than zero
+- FuelType must be a valid enum value (gasoline, diesel, e85)
+
+**Example:**
+
+```go
+price := 3.459
+record := &models.FuelRecord{
+    VehicleID:    vehicleID,
+    FillDate:     time.Now(),
+    Mileage:      50000,
+    Volume:       12.5,
+    FuelType:     "gasoline",
+    PricePerUnit: &price,
+}
+err := repo.Create(ctx, record)
+```
+
+#### FindByID
+
+Retrieves a fuel record by its ID.
+
+```go
+FindByID(ctx context.Context, id string) (*models.FuelRecord, error)
+```
+
+**Returns:**
+
+- `*models.FuelRecord`: Record if found
+- `error`: `*models.NotFoundError` if record doesn't exist
+
+#### FindByVehicleID
+
+Retrieves all fuel records for a specific vehicle, ordered by fill date descending.
+
+```go
+FindByVehicleID(ctx context.Context, vehicleID string) ([]*models.FuelRecord, error)
+```
+
+**Returns:**
+
+- `[]*models.FuelRecord`: Slice of records (empty if none found)
+- `error`: Database errors only
+
+#### Update
+
+Modifies an existing fuel record.
+
+```go
+Update(ctx context.Context, record *models.FuelRecord) error
+```
+
+**Returns:**
+
+- `error`: `*models.NotFoundError` if record doesn't exist, `*models.ValidationError` if validation fails
+
+#### Delete
+
+Removes a fuel record from the database.
+
+```go
+Delete(ctx context.Context, id string) error
+```
+
+**Returns:**
+
+- `error`: `*models.NotFoundError` if record doesn't exist
+
+#### List
+
+Retrieves fuel records with optional filters and pagination.
+
+```go
+List(ctx context.Context, filters FuelFilters, pagination PaginationParams) ([]*models.FuelRecord, error)
+```
+
+#### Count
+
+Returns the total number of fuel records matching the filters.
+
+```go
+Count(ctx context.Context, filters FuelFilters) (int, error)
 ```
 
 ---
@@ -537,6 +713,7 @@ type NotFoundError struct {
 ```
 
 **Handling:**
+
 ```go
 user, err := repo.FindByID(ctx, id)
 if err != nil {
@@ -560,6 +737,7 @@ type ValidationError struct {
 ```
 
 **Handling:**
+
 ```go
 err := repo.Create(ctx, user)
 if err != nil {
@@ -584,6 +762,7 @@ type DuplicateError struct {
 ```
 
 **Handling:**
+
 ```go
 err := repo.Create(ctx, user)
 if err != nil {
@@ -652,6 +831,7 @@ if err := tx.Commit(); err != nil {
 ### Context Support
 
 All repository methods accept a `context.Context` for:
+
 - **Cancellation**: Cancel long-running queries
 - **Timeouts**: Set query timeouts
 - **Tracing**: Propagate request IDs for logging

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -13,6 +13,7 @@ ValidateUser(u *User) error
 ValidatePassword(password string) error
 ValidateVehicle(v *Vehicle) error
 ValidateMaintenanceRecord(m *MaintenanceRecord) error
+ValidateFuelRecord(f *FuelRecord) error
 ```
 
 ## User Validation
@@ -47,12 +48,14 @@ if err != nil {
 Valid usernames match the pattern: `^[a-zA-Z0-9_\-]+$`
 
 **Valid Examples:**
+
 - `johndoe`
 - `john_doe`
 - `john-doe`
 - `JohnDoe123`
 
 **Invalid Examples:**
+
 - `john doe` (contains space)
 - `john@doe` (contains @)
 - `jo` (too short)
@@ -62,11 +65,13 @@ Valid usernames match the pattern: `^[a-zA-Z0-9_\-]+$`
 Valid emails match a standard email pattern.
 
 **Valid Examples:**
+
 - `john@example.com`
 - `john.doe@example.co.uk`
 - `john+tag@example.com`
 
 **Invalid Examples:**
+
 - `john@` (incomplete)
 - `@example.com` (no local part)
 - `john` (no domain)
@@ -104,11 +109,13 @@ if err != nil {
 4. **Digit**: At least one 0-9
 
 **Valid Examples:**
+
 - `Password1` ✓
 - `MySecure123` ✓
 - `Abc12345` ✓
 
 **Invalid Examples:**
+
 - `password` ✗ (no uppercase, no digit)
 - `PASSWORD1` ✗ (no lowercase)
 - `Password` ✗ (no digit)
@@ -154,6 +161,7 @@ if err != nil {
 ### VIN Format
 
 Vehicle Identification Numbers (VINs) must:
+
 1. Be exactly 17 characters
 2. Contain only alphanumeric characters (A-Z, 0-9)
 3. Not contain letters I, O, or Q (to avoid confusion with 1 and 0)
@@ -161,11 +169,13 @@ Vehicle Identification Numbers (VINs) must:
 **VIN Pattern**: `^[A-HJ-NPR-Z0-9]{17}$`
 
 **Valid Examples:**
+
 - `1HGCM82633A004352`
 - `WVWZZZ3CZWE123456`
 - `5YJSA1S20EFP12345`
 
 **Invalid Examples:**
+
 - `1HGCM82633A00435` (16 characters)
 - `1HGCM82633A0043521` (18 characters)
 - `1HGCM826I3A004352` (contains I)
@@ -173,6 +183,7 @@ Vehicle Identification Numbers (VINs) must:
 - `1HGCM8263QA004352` (contains Q)
 
 **VIN Normalization:**
+
 - Spaces are automatically removed
 - Letters are converted to uppercase
 
@@ -185,16 +196,19 @@ Vehicle Identification Numbers (VINs) must:
 ### Year Validation
 
 The year must be:
+
 - At least 1900 (minimum supported year)
 - At most current year + 1 (allows for next model year vehicles)
 
 **Example (in 2024):**
+
 - Valid: 1900, 1950, 2020, 2024, 2025
 - Invalid: 1899, 2026, 2030
 
 ### Vehicle Status
 
 Valid status values:
+
 - `active` - Vehicle is currently in use
 - `sold` - Vehicle has been sold
 - `scrapped` - Vehicle has been disposed of
@@ -272,10 +286,62 @@ When `service_type` is `"other"`, the `custom_service_type` field must be provid
 ### Service Date
 
 The service date:
+
 - Cannot be empty (zero value)
 - Cannot be in the future
 
 This prevents scheduling future maintenance as completed work.
+
+---
+
+## Fuel Record Validation
+
+### ValidateFuelRecord
+
+Validates a FuelRecord model before creation or update.
+
+```go
+err := models.ValidateFuelRecord(record)
+if err != nil {
+    var valErr *models.ValidationError
+    if errors.As(err, &valErr) {
+        fmt.Printf("Field: %s, Error: %s\n", valErr.Field, valErr.Message)
+    }
+}
+```
+
+### Field Rules
+
+| Field | Rule | Error Message |
+|-------|------|---------------|
+| `vehicle_id` | Required | "vehicle ID is required" |
+| `fill_date` | Required (non-zero) | "fill date is required" |
+| `fill_date` | Not in the future | "fill date cannot be in the future" |
+| `mileage` | Must be > 0 | "mileage must be greater than zero" |
+| `volume` | Must be > 0 | "volume must be greater than zero" |
+| `fuel_type` | Required | "fuel type is required" |
+| `fuel_type` | Must be valid enum value | "invalid fuel type" |
+| `price_per_unit` | Non-negative if provided | "price per unit cannot be negative" |
+| `octane_rating` | Greater than zero if provided | "octane rating must be greater than zero" |
+| `city_driving_percentage` | 0-100 if provided | "city driving percentage must be between 0 and 100" |
+| `vehicle_reported_mpg` | Greater than zero if provided | "vehicle reported MPG must be greater than zero" |
+
+### Fuel Types
+
+The `fuel_type` field must be one of the following:
+
+| Enum Value | Display Name |
+|-----------|-------------|
+| `gasoline` | Gasoline |
+| `diesel` | Diesel |
+| `e85` | E85 |
+
+### Fill Date
+
+The fill date:
+
+- Cannot be empty (zero value)
+- Cannot be in the future
 
 ---
 

--- a/internal/models/fuel.go
+++ b/internal/models/fuel.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"time"
+)
+
+// FuelType represents the type of fuel used for a fill-up.
+type FuelType string
+
+const (
+	FuelTypeGasoline FuelType = "gasoline"
+	FuelTypeDiesel   FuelType = "diesel"
+	FuelTypeE85      FuelType = "e85"
+)
+
+// fuelTypeDisplayNames maps enum values to human-readable display names.
+var fuelTypeDisplayNames = map[FuelType]string{
+	FuelTypeGasoline: "Gasoline",
+	FuelTypeDiesel:   "Diesel",
+	FuelTypeE85:      "E85",
+}
+
+// allFuelTypes defines the canonical order for dropdowns and iteration.
+var allFuelTypes = []FuelType{
+	FuelTypeGasoline,
+	FuelTypeDiesel,
+	FuelTypeE85,
+}
+
+// IsValidFuelType returns true if the given string is a recognized fuel type.
+func IsValidFuelType(s string) bool {
+	_, ok := fuelTypeDisplayNames[FuelType(s)]
+	return ok
+}
+
+// FuelTypeDisplayName returns the human-readable display name for a fuel type enum value.
+// It returns the raw value if the fuel type is not recognized.
+func FuelTypeDisplayName(s string) string {
+	if name, ok := fuelTypeDisplayNames[FuelType(s)]; ok {
+		return name
+	}
+	return s
+}
+
+// AllFuelTypes returns all valid fuel types in display order.
+func AllFuelTypes() []FuelType {
+	result := make([]FuelType, len(allFuelTypes))
+	copy(result, allFuelTypes)
+	return result
+}
+
+// FuelRecord represents a fuel fill-up record for a vehicle.
+type FuelRecord struct {
+	ID                    string
+	VehicleID             string
+	FillDate              time.Time
+	Mileage               int
+	Volume                float64
+	FuelType              string
+	PartialFill           bool
+	PricePerUnit          *float64
+	OctaneRating          *int
+	Location              string
+	Brand                 string
+	Notes                 string
+	CityDrivingPercentage *int
+	VehicleReportedMPG    *float64
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}

--- a/internal/models/fuel_test.go
+++ b/internal/models/fuel_test.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidFuelType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"gasoline is valid", "gasoline", true},
+		{"diesel is valid", "diesel", true},
+		{"e85 is valid", "e85", true},
+		{"empty is invalid", "", false},
+		{"unknown is invalid", "propane", false},
+		{"uppercase is invalid", "Gasoline", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsValidFuelType(tt.input))
+		})
+	}
+}
+
+func TestFuelTypeDisplayName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"gasoline display name", "gasoline", "Gasoline"},
+		{"diesel display name", "diesel", "Diesel"},
+		{"e85 display name", "e85", "E85"},
+		{"unknown returns raw value", "propane", "propane"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, FuelTypeDisplayName(tt.input))
+		})
+	}
+}
+
+func TestAllFuelTypes(t *testing.T) {
+	types := AllFuelTypes()
+
+	assert.Len(t, types, 3)
+	assert.Equal(t, FuelTypeGasoline, types[0])
+	assert.Equal(t, FuelTypeDiesel, types[1])
+	assert.Equal(t, FuelTypeE85, types[2])
+
+	// Verify it returns a copy, not the original slice
+	types[0] = "modified"
+	original := AllFuelTypes()
+	assert.Equal(t, FuelTypeGasoline, original[0])
+}

--- a/internal/models/validation.go
+++ b/internal/models/validation.go
@@ -209,3 +209,52 @@ func ValidateMaintenanceRecord(m *MaintenanceRecord) error {
 
 	return nil
 }
+
+// ValidateFuelRecord validates a FuelRecord model
+func ValidateFuelRecord(f *FuelRecord) error {
+	if f.VehicleID == "" {
+		return NewValidationError("vehicle_id", "vehicle ID is required")
+	}
+
+	if f.FillDate.IsZero() {
+		return NewValidationError("fill_date", "fill date is required")
+	}
+
+	if f.FillDate.After(time.Now()) {
+		return NewValidationError("fill_date", "fill date cannot be in the future")
+	}
+
+	if f.Mileage <= 0 {
+		return NewValidationError("mileage", "mileage must be greater than zero")
+	}
+
+	if f.Volume <= 0 {
+		return NewValidationError("volume", "volume must be greater than zero")
+	}
+
+	if f.FuelType == "" {
+		return NewValidationError("fuel_type", "fuel type is required")
+	}
+
+	if !IsValidFuelType(f.FuelType) {
+		return NewValidationError("fuel_type", "invalid fuel type")
+	}
+
+	if f.PricePerUnit != nil && *f.PricePerUnit < 0 {
+		return NewValidationError("price_per_unit", "price per unit cannot be negative")
+	}
+
+	if f.OctaneRating != nil && *f.OctaneRating <= 0 {
+		return NewValidationError("octane_rating", "octane rating must be greater than zero")
+	}
+
+	if f.CityDrivingPercentage != nil && (*f.CityDrivingPercentage < 0 || *f.CityDrivingPercentage > 100) {
+		return NewValidationError("city_driving_percentage", "city driving percentage must be between 0 and 100")
+	}
+
+	if f.VehicleReportedMPG != nil && *f.VehicleReportedMPG <= 0 {
+		return NewValidationError("vehicle_reported_mpg", "vehicle reported MPG must be greater than zero")
+	}
+
+	return nil
+}

--- a/internal/models/validation_test.go
+++ b/internal/models/validation_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -159,6 +160,161 @@ func TestValidateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateUser(tt.user)
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorField != "" {
+					assert.Contains(t, err.Error(), tt.errorField)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func validFuelRecord() *FuelRecord {
+	return &FuelRecord{
+		VehicleID: "vehicle-123",
+		FillDate:  time.Now().Add(-24 * time.Hour),
+		Mileage:   50000,
+		Volume:    12.5,
+		FuelType:  "gasoline",
+	}
+}
+
+func TestValidateFuelRecord(t *testing.T) {
+	negativeFloat := -1.0
+	zeroFloat := 0.0
+	positiveFloat := 3.50
+	negativeInt := -5
+	validPercentage := 50
+	tooHighPercentage := 101
+	validOctane := 87
+	zeroOctane := 0
+	validMPG := 32.5
+	negativeMPG := -1.0
+
+	tests := []struct {
+		name        string
+		modify      func(f *FuelRecord)
+		expectError bool
+		errorField  string
+	}{
+		{
+			name:        "valid fuel record",
+			modify:      func(f *FuelRecord) {},
+			expectError: false,
+		},
+		{
+			name: "valid with all optional fields",
+			modify: func(f *FuelRecord) {
+				f.PartialFill = true
+				f.PricePerUnit = &positiveFloat
+				f.OctaneRating = &validOctane
+				f.Location = "Shell Station"
+				f.Brand = "Shell"
+				f.Notes = "Premium fuel"
+				f.CityDrivingPercentage = &validPercentage
+				f.VehicleReportedMPG = &validMPG
+			},
+			expectError: false,
+		},
+		{
+			name:        "missing vehicle_id",
+			modify:      func(f *FuelRecord) { f.VehicleID = "" },
+			expectError: true,
+			errorField:  "vehicle_id",
+		},
+		{
+			name:        "missing fill_date",
+			modify:      func(f *FuelRecord) { f.FillDate = time.Time{} },
+			expectError: true,
+			errorField:  "fill_date",
+		},
+		{
+			name:        "future fill_date",
+			modify:      func(f *FuelRecord) { f.FillDate = time.Now().Add(48 * time.Hour) },
+			expectError: true,
+			errorField:  "fill_date",
+		},
+		{
+			name:        "zero mileage",
+			modify:      func(f *FuelRecord) { f.Mileage = 0 },
+			expectError: true,
+			errorField:  "mileage",
+		},
+		{
+			name:        "negative mileage",
+			modify:      func(f *FuelRecord) { f.Mileage = -100 },
+			expectError: true,
+			errorField:  "mileage",
+		},
+		{
+			name:        "zero volume",
+			modify:      func(f *FuelRecord) { f.Volume = 0 },
+			expectError: true,
+			errorField:  "volume",
+		},
+		{
+			name:        "negative volume",
+			modify:      func(f *FuelRecord) { f.Volume = -5.0 },
+			expectError: true,
+			errorField:  "volume",
+		},
+		{
+			name:        "empty fuel_type",
+			modify:      func(f *FuelRecord) { f.FuelType = "" },
+			expectError: true,
+			errorField:  "fuel_type",
+		},
+		{
+			name:        "invalid fuel_type",
+			modify:      func(f *FuelRecord) { f.FuelType = "propane" },
+			expectError: true,
+			errorField:  "fuel_type",
+		},
+		{
+			name:        "negative price_per_unit",
+			modify:      func(f *FuelRecord) { f.PricePerUnit = &negativeFloat },
+			expectError: true,
+			errorField:  "price_per_unit",
+		},
+		{
+			name:        "zero price_per_unit is valid",
+			modify:      func(f *FuelRecord) { f.PricePerUnit = &zeroFloat },
+			expectError: false,
+		},
+		{
+			name:        "zero octane_rating",
+			modify:      func(f *FuelRecord) { f.OctaneRating = &zeroOctane },
+			expectError: true,
+			errorField:  "octane_rating",
+		},
+		{
+			name:        "negative city_driving_percentage",
+			modify:      func(f *FuelRecord) { f.CityDrivingPercentage = &negativeInt },
+			expectError: true,
+			errorField:  "city_driving_percentage",
+		},
+		{
+			name:        "city_driving_percentage over 100",
+			modify:      func(f *FuelRecord) { f.CityDrivingPercentage = &tooHighPercentage },
+			expectError: true,
+			errorField:  "city_driving_percentage",
+		},
+		{
+			name:        "negative vehicle_reported_mpg",
+			modify:      func(f *FuelRecord) { f.VehicleReportedMPG = &negativeMPG },
+			expectError: true,
+			errorField:  "vehicle_reported_mpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := validFuelRecord()
+			tt.modify(f)
+			err := ValidateFuelRecord(f)
 			if tt.expectError {
 				assert.Error(t, err)
 				if tt.errorField != "" {

--- a/internal/repositories/fuel.go
+++ b/internal/repositories/fuel.go
@@ -1,0 +1,37 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/truggeri/go-garage/internal/models"
+)
+
+// FuelFilters contains optional filters for listing fuel records
+type FuelFilters struct {
+	VehicleID *string
+	FuelType  *string
+}
+
+// FuelRepository defines the interface for fuel record data access
+type FuelRepository interface {
+	// Create inserts a new fuel record into the database
+	Create(ctx context.Context, record *models.FuelRecord) error
+
+	// FindByID retrieves a fuel record by its ID
+	FindByID(ctx context.Context, id string) (*models.FuelRecord, error)
+
+	// FindByVehicleID retrieves all fuel records for a specific vehicle
+	FindByVehicleID(ctx context.Context, vehicleID string) ([]*models.FuelRecord, error)
+
+	// Update modifies an existing fuel record
+	Update(ctx context.Context, record *models.FuelRecord) error
+
+	// Delete removes a fuel record from the database
+	Delete(ctx context.Context, id string) error
+
+	// List retrieves fuel records with optional filters and pagination
+	List(ctx context.Context, filters FuelFilters, pagination PaginationParams) ([]*models.FuelRecord, error)
+
+	// Count returns the total number of fuel records matching the filters
+	Count(ctx context.Context, filters FuelFilters) (int, error)
+}

--- a/internal/repositories/fuel_sqlite.go
+++ b/internal/repositories/fuel_sqlite.go
@@ -1,0 +1,130 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/truggeri/go-garage/internal/models"
+)
+
+// SQLiteFuelRepository implements FuelRepository using SQLite
+type SQLiteFuelRepository struct {
+	db *sql.DB
+}
+
+// NewSQLiteFuelRepository creates a new SQLite-based fuel repository
+func NewSQLiteFuelRepository(db *sql.DB) *SQLiteFuelRepository {
+	return &SQLiteFuelRepository{db: db}
+}
+
+// Create inserts a new fuel record into the database
+func (r *SQLiteFuelRepository) Create(ctx context.Context, record *models.FuelRecord) error {
+	if err := models.ValidateFuelRecord(record); err != nil {
+		return err
+	}
+
+	if record.ID == "" {
+		record.ID = uuid.New().String()
+	}
+
+	now := time.Now()
+	record.CreatedAt = now
+	record.UpdatedAt = now
+
+	query := `
+		INSERT INTO fuel_records (
+			id, vehicle_id, fill_date, mileage, volume, fuel_type, partial_fill,
+			price_per_unit, octane_rating, location, brand, notes,
+			city_driving_percentage, vehicle_reported_mpg, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		record.ID, record.VehicleID, record.FillDate, record.Mileage,
+		record.Volume, record.FuelType, record.PartialFill,
+		record.PricePerUnit, record.OctaneRating,
+		nullableString(record.Location), nullableString(record.Brand),
+		nullableString(record.Notes),
+		record.CityDrivingPercentage, record.VehicleReportedMPG,
+		record.CreatedAt, record.UpdatedAt,
+	)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			return models.NewValidationError("vehicle_id", "vehicle does not exist")
+		}
+		return models.NewDatabaseError("create fuel record", err)
+	}
+
+	return nil
+}
+
+// Update modifies an existing fuel record
+func (r *SQLiteFuelRepository) Update(ctx context.Context, record *models.FuelRecord) error {
+	if err := models.ValidateFuelRecord(record); err != nil {
+		return err
+	}
+
+	record.UpdatedAt = time.Now()
+
+	query := `
+		UPDATE fuel_records
+		SET vehicle_id = ?, fill_date = ?, mileage = ?, volume = ?, fuel_type = ?,
+		    partial_fill = ?, price_per_unit = ?, octane_rating = ?, location = ?,
+		    brand = ?, notes = ?, city_driving_percentage = ?,
+		    vehicle_reported_mpg = ?, updated_at = ?
+		WHERE id = ?
+	`
+
+	result, err := r.db.ExecContext(ctx, query,
+		record.VehicleID, record.FillDate, record.Mileage, record.Volume,
+		record.FuelType, record.PartialFill,
+		record.PricePerUnit, record.OctaneRating,
+		nullableString(record.Location), nullableString(record.Brand),
+		nullableString(record.Notes),
+		record.CityDrivingPercentage, record.VehicleReportedMPG,
+		record.UpdatedAt, record.ID,
+	)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			return models.NewValidationError("vehicle_id", "vehicle does not exist")
+		}
+		return models.NewDatabaseError("update fuel record", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return models.NewDatabaseError("update fuel record check", err)
+	}
+
+	if rowsAffected == 0 {
+		return models.NewNotFoundError("FuelRecord", record.ID)
+	}
+
+	return nil
+}
+
+// Delete removes a fuel record from the database
+func (r *SQLiteFuelRepository) Delete(ctx context.Context, id string) error {
+	query := `DELETE FROM fuel_records WHERE id = ?`
+
+	result, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return models.NewDatabaseError("delete fuel record", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return models.NewDatabaseError("delete fuel record check", err)
+	}
+
+	if rowsAffected == 0 {
+		return models.NewNotFoundError("FuelRecord", id)
+	}
+
+	return nil
+}

--- a/internal/repositories/fuel_sqlite_read.go
+++ b/internal/repositories/fuel_sqlite_read.go
@@ -1,0 +1,173 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/truggeri/go-garage/internal/models"
+)
+
+const fuelRecordColumns = `id, vehicle_id, fill_date, mileage, volume, fuel_type, partial_fill,
+	price_per_unit, octane_rating, location, brand, notes,
+	city_driving_percentage, vehicle_reported_mpg, created_at, updated_at`
+
+// nullableString returns a sql.NullString for empty strings
+func nullableString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}
+
+// scanFuelRecord scans a single row into a FuelRecord
+func scanFuelRecord(scanner interface{ Scan(...interface{}) error }) (*models.FuelRecord, error) {
+	record := &models.FuelRecord{}
+	var pricePerUnit sql.NullFloat64
+	var octaneRating, cityDrivingPercentage sql.NullInt64
+	var location, brand, notes sql.NullString
+	var vehicleReportedMPG sql.NullFloat64
+
+	err := scanner.Scan(
+		&record.ID, &record.VehicleID, &record.FillDate, &record.Mileage,
+		&record.Volume, &record.FuelType, &record.PartialFill,
+		&pricePerUnit, &octaneRating,
+		&location, &brand, &notes,
+		&cityDrivingPercentage, &vehicleReportedMPG,
+		&record.CreatedAt, &record.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if pricePerUnit.Valid {
+		record.PricePerUnit = &pricePerUnit.Float64
+	}
+	if octaneRating.Valid {
+		o := int(octaneRating.Int64)
+		record.OctaneRating = &o
+	}
+	if location.Valid {
+		record.Location = location.String
+	}
+	if brand.Valid {
+		record.Brand = brand.String
+	}
+	if notes.Valid {
+		record.Notes = notes.String
+	}
+	if cityDrivingPercentage.Valid {
+		c := int(cityDrivingPercentage.Int64)
+		record.CityDrivingPercentage = &c
+	}
+	if vehicleReportedMPG.Valid {
+		record.VehicleReportedMPG = &vehicleReportedMPG.Float64
+	}
+
+	return record, nil
+}
+
+// scanFuelRecords scans multiple rows into FuelRecord slices
+func scanFuelRecords(rows *sql.Rows) ([]*models.FuelRecord, error) {
+	records := []*models.FuelRecord{}
+	for rows.Next() {
+		record, err := scanFuelRecord(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan fuel record row: %w", err)
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate fuel record rows: %w", err)
+	}
+	return records, nil
+}
+
+// FindByID retrieves a fuel record by its ID
+func (r *SQLiteFuelRepository) FindByID(ctx context.Context, id string) (*models.FuelRecord, error) {
+	query := `SELECT ` + fuelRecordColumns + ` FROM fuel_records WHERE id = ?`
+
+	record, err := scanFuelRecord(r.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, models.NewNotFoundError("FuelRecord", id)
+		}
+		return nil, models.NewDatabaseError("find fuel record by ID", err)
+	}
+
+	return record, nil
+}
+
+// FindByVehicleID retrieves all fuel records for a specific vehicle
+func (r *SQLiteFuelRepository) FindByVehicleID(ctx context.Context, vehicleID string) ([]*models.FuelRecord, error) {
+	query := `SELECT ` + fuelRecordColumns + ` FROM fuel_records WHERE vehicle_id = ? ORDER BY fill_date DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, vehicleID)
+	if err != nil {
+		return nil, models.NewDatabaseError("find fuel records by vehicle ID", err)
+	}
+	defer rows.Close()
+
+	return scanFuelRecords(rows)
+}
+
+// List retrieves fuel records with optional filters and pagination
+func (r *SQLiteFuelRepository) List(ctx context.Context, filters FuelFilters, pagination PaginationParams) ([]*models.FuelRecord, error) {
+	query := `SELECT ` + fuelRecordColumns + ` FROM fuel_records WHERE 1=1`
+	args := []interface{}{}
+
+	if filters.VehicleID != nil {
+		query += sqlFilterVehicleID
+		args = append(args, *filters.VehicleID)
+	}
+
+	if filters.FuelType != nil {
+		query += " AND fuel_type = ?"
+		args = append(args, *filters.FuelType)
+	}
+
+	query += " ORDER BY fill_date DESC"
+
+	if pagination.Limit > 0 {
+		query += sqlLimit
+		args = append(args, pagination.Limit)
+	}
+
+	if pagination.Offset > 0 {
+		query += sqlOffset
+		args = append(args, pagination.Offset)
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, models.NewDatabaseError("list fuel records", err)
+	}
+	defer rows.Close()
+
+	return scanFuelRecords(rows)
+}
+
+// Count returns the total number of fuel records matching the filters
+func (r *SQLiteFuelRepository) Count(ctx context.Context, filters FuelFilters) (int, error) {
+	query := `SELECT COUNT(*) FROM fuel_records WHERE 1=1`
+	args := []interface{}{}
+
+	if filters.VehicleID != nil {
+		query += sqlFilterVehicleID
+		args = append(args, *filters.VehicleID)
+	}
+
+	if filters.FuelType != nil {
+		query += " AND fuel_type = ?"
+		args = append(args, *filters.FuelType)
+	}
+
+	var count int
+	err := r.db.QueryRowContext(ctx, query, args...).Scan(&count)
+	if err != nil {
+		return 0, models.NewDatabaseError("count fuel records", err)
+	}
+
+	return count, nil
+}

--- a/internal/repositories/fuel_sqlite_test.go
+++ b/internal/repositories/fuel_sqlite_test.go
@@ -1,0 +1,344 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/truggeri/go-garage/internal/models"
+)
+
+// setupFuelTestData creates prerequisite user and vehicle for fuel tests
+func setupFuelTestData(t *testing.T) (*SQLiteFuelRepository, *models.Vehicle, context.Context, func()) {
+	t.Helper()
+
+	db, cleanup := setupTestDB(t)
+	userRepo := NewSQLiteUserRepository(db)
+	vehicleRepo := NewSQLiteVehicleRepository(db)
+	fuelRepo := NewSQLiteFuelRepository(db)
+	ctx := context.Background()
+
+	user := &models.User{
+		Username:     "fuelowner",
+		Email:        "fuel@example.com",
+		PasswordHash: "hashed_password",
+	}
+	require.NoError(t, userRepo.Create(ctx, user))
+
+	vehicle := &models.Vehicle{
+		UserID: user.ID,
+		VIN:    "FUELH41JXMN109201",
+		Make:   "Toyota",
+		Model:  "Corolla",
+		Year:   2022,
+		Status: models.VehicleStatusActive,
+	}
+	require.NoError(t, vehicleRepo.Create(ctx, vehicle))
+
+	return fuelRepo, vehicle, ctx, cleanup
+}
+
+func validTestFuelRecord(vehicleID string) *models.FuelRecord {
+	return &models.FuelRecord{
+		VehicleID: vehicleID,
+		FillDate:  time.Now().Add(-24 * time.Hour),
+		Mileage:   50000,
+		Volume:    12.5,
+		FuelType:  "gasoline",
+	}
+}
+
+func TestFuelRepository_Create(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	t.Run("create valid fuel record", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		err := fuelRepo.Create(ctx, record)
+		require.NoError(t, err)
+		assert.NotEmpty(t, record.ID)
+		assert.False(t, record.CreatedAt.IsZero())
+		assert.False(t, record.UpdatedAt.IsZero())
+	})
+
+	t.Run("create with all fields", func(t *testing.T) {
+		price := 3.459
+		octane := 93
+		cityPct := 60
+		mpg := 32.5
+
+		record := &models.FuelRecord{
+			VehicleID:             vehicle.ID,
+			FillDate:              time.Now().Add(-48 * time.Hour),
+			Mileage:               50300,
+			Volume:                14.2,
+			FuelType:              "gasoline",
+			PartialFill:           true,
+			PricePerUnit:          &price,
+			OctaneRating:          &octane,
+			Location:              "Shell Station",
+			Brand:                 "Shell",
+			Notes:                 "Premium fuel",
+			CityDrivingPercentage: &cityPct,
+			VehicleReportedMPG:    &mpg,
+		}
+
+		err := fuelRepo.Create(ctx, record)
+		require.NoError(t, err)
+		assert.NotEmpty(t, record.ID)
+	})
+
+	t.Run("invalid vehicle ID", func(t *testing.T) {
+		record := validTestFuelRecord("non-existent-vehicle")
+		err := fuelRepo.Create(ctx, record)
+		require.Error(t, err)
+		assert.IsType(t, &models.ValidationError{}, err)
+		assert.Contains(t, err.Error(), "vehicle does not exist")
+	})
+
+	t.Run("validation error empty fuel type", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		record.FuelType = ""
+		err := fuelRepo.Create(ctx, record)
+		require.Error(t, err)
+		assert.IsType(t, &models.ValidationError{}, err)
+	})
+}
+
+func TestFuelRepository_FindByID(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	t.Run("find existing record", func(t *testing.T) {
+		price := 3.50
+		octane := 87
+		record := &models.FuelRecord{
+			VehicleID:    vehicle.ID,
+			FillDate:     time.Now().Add(-24 * time.Hour),
+			Mileage:      50000,
+			Volume:       12.5,
+			FuelType:     string(models.FuelTypeDiesel),
+			PartialFill:  false,
+			PricePerUnit: &price,
+			OctaneRating: &octane,
+			Location:     "Costco",
+			Brand:        "Kirkland",
+			Notes:        "Cheap fuel",
+		}
+		require.NoError(t, fuelRepo.Create(ctx, record))
+
+		found, err := fuelRepo.FindByID(ctx, record.ID)
+		require.NoError(t, err)
+		assert.Equal(t, record.ID, found.ID)
+		assert.Equal(t, vehicle.ID, found.VehicleID)
+		assert.Equal(t, 50000, found.Mileage)
+		assert.Equal(t, 12.5, found.Volume)
+		assert.Equal(t, string(models.FuelTypeDiesel), found.FuelType)
+		assert.False(t, found.PartialFill)
+		assert.InDelta(t, 3.50, *found.PricePerUnit, 0.001)
+		assert.Equal(t, 87, *found.OctaneRating)
+		assert.Equal(t, "Costco", found.Location)
+		assert.Equal(t, "Kirkland", found.Brand)
+		assert.Equal(t, "Cheap fuel", found.Notes)
+	})
+
+	t.Run("find with nullable fields nil", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		require.NoError(t, fuelRepo.Create(ctx, record))
+
+		found, err := fuelRepo.FindByID(ctx, record.ID)
+		require.NoError(t, err)
+		assert.Nil(t, found.PricePerUnit)
+		assert.Nil(t, found.OctaneRating)
+		assert.Empty(t, found.Location)
+		assert.Empty(t, found.Brand)
+		assert.Empty(t, found.Notes)
+		assert.Nil(t, found.CityDrivingPercentage)
+		assert.Nil(t, found.VehicleReportedMPG)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		found, err := fuelRepo.FindByID(ctx, "non-existent-id")
+		assert.Nil(t, found)
+		assert.Error(t, err)
+		assert.IsType(t, &models.NotFoundError{}, err)
+	})
+}
+
+func TestFuelRepository_FindByVehicleID(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	// Create multiple records
+	for i := 0; i < 3; i++ {
+		record := validTestFuelRecord(vehicle.ID)
+		record.Mileage = 50000 + (i * 300)
+		record.FillDate = time.Now().Add(-time.Duration(i+1) * 24 * time.Hour)
+		require.NoError(t, fuelRepo.Create(ctx, record))
+	}
+
+	t.Run("returns records ordered by fill_date desc", func(t *testing.T) {
+		records, err := fuelRepo.FindByVehicleID(ctx, vehicle.ID)
+		require.NoError(t, err)
+		assert.Len(t, records, 3)
+		// Most recent first
+		assert.True(t, records[0].FillDate.After(records[1].FillDate))
+		assert.True(t, records[1].FillDate.After(records[2].FillDate))
+	})
+
+	t.Run("returns empty for unknown vehicle", func(t *testing.T) {
+		records, err := fuelRepo.FindByVehicleID(ctx, "unknown-vehicle")
+		require.NoError(t, err)
+		assert.Empty(t, records)
+	})
+}
+
+func TestFuelRepository_Update(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	t.Run("update existing record", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		require.NoError(t, fuelRepo.Create(ctx, record))
+
+		record.Mileage = 55000
+		record.Volume = 15.0
+		record.FuelType = "e85"
+		record.PartialFill = true
+
+		err := fuelRepo.Update(ctx, record)
+		require.NoError(t, err)
+
+		found, err := fuelRepo.FindByID(ctx, record.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 55000, found.Mileage)
+		assert.Equal(t, 15.0, found.Volume)
+		assert.Equal(t, "e85", found.FuelType)
+		assert.True(t, found.PartialFill)
+	})
+
+	t.Run("update non-existent record", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		record.ID = "non-existent-id"
+		err := fuelRepo.Update(ctx, record)
+		assert.Error(t, err)
+		assert.IsType(t, &models.NotFoundError{}, err)
+	})
+
+	t.Run("update with validation error", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		require.NoError(t, fuelRepo.Create(ctx, record))
+
+		record.Mileage = 0
+		err := fuelRepo.Update(ctx, record)
+		assert.Error(t, err)
+		assert.IsType(t, &models.ValidationError{}, err)
+	})
+}
+
+func TestFuelRepository_Delete(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	t.Run("delete existing record", func(t *testing.T) {
+		record := validTestFuelRecord(vehicle.ID)
+		require.NoError(t, fuelRepo.Create(ctx, record))
+
+		err := fuelRepo.Delete(ctx, record.ID)
+		require.NoError(t, err)
+
+		found, err := fuelRepo.FindByID(ctx, record.ID)
+		assert.Nil(t, found)
+		assert.Error(t, err)
+	})
+
+	t.Run("delete non-existent record", func(t *testing.T) {
+		err := fuelRepo.Delete(ctx, "non-existent-id")
+		assert.Error(t, err)
+		assert.IsType(t, &models.NotFoundError{}, err)
+	})
+}
+
+func TestFuelRepository_List(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	// Create records with different fuel types
+	for i, ft := range []string{string(models.FuelTypeGasoline), string(models.FuelTypeDiesel), string(models.FuelTypeGasoline)} {
+		record := validTestFuelRecord(vehicle.ID)
+		record.Mileage = 50000 + (i * 300)
+		record.FuelType = ft
+		record.FillDate = time.Now().Add(-time.Duration(i+1) * 24 * time.Hour)
+		require.NoError(t, fuelRepo.Create(ctx, record))
+	}
+
+	t.Run("list all", func(t *testing.T) {
+		records, err := fuelRepo.List(ctx, FuelFilters{}, PaginationParams{})
+		require.NoError(t, err)
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("filter by vehicle_id", func(t *testing.T) {
+		vid := vehicle.ID
+		records, err := fuelRepo.List(ctx, FuelFilters{VehicleID: &vid}, PaginationParams{})
+		require.NoError(t, err)
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("filter by fuel_type", func(t *testing.T) {
+		ft := string(models.FuelTypeDiesel)
+		records, err := fuelRepo.List(ctx, FuelFilters{FuelType: &ft}, PaginationParams{})
+		require.NoError(t, err)
+		assert.Len(t, records, 1)
+		assert.Equal(t, string(models.FuelTypeDiesel), records[0].FuelType)
+	})
+
+	t.Run("pagination limit", func(t *testing.T) {
+		records, err := fuelRepo.List(ctx, FuelFilters{}, PaginationParams{Limit: 2})
+		require.NoError(t, err)
+		assert.Len(t, records, 2)
+	})
+
+	t.Run("pagination offset", func(t *testing.T) {
+		records, err := fuelRepo.List(ctx, FuelFilters{}, PaginationParams{Limit: 10, Offset: 2})
+		require.NoError(t, err)
+		assert.Len(t, records, 1)
+	})
+}
+
+func TestFuelRepository_Count(t *testing.T) {
+	fuelRepo, vehicle, ctx, cleanup := setupFuelTestData(t)
+	defer cleanup()
+
+	for i := 0; i < 3; i++ {
+		record := validTestFuelRecord(vehicle.ID)
+		record.Mileage = 50000 + (i * 300)
+		record.FillDate = time.Now().Add(-time.Duration(i+1) * 24 * time.Hour)
+		if i == 0 {
+			record.FuelType = string(models.FuelTypeDiesel)
+		}
+		require.NoError(t, fuelRepo.Create(ctx, record))
+	}
+
+	t.Run("count all", func(t *testing.T) {
+		count, err := fuelRepo.Count(ctx, FuelFilters{})
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("count with fuel_type filter", func(t *testing.T) {
+		ft := string(models.FuelTypeDiesel)
+		count, err := fuelRepo.Count(ctx, FuelFilters{FuelType: &ft})
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("count with no matches", func(t *testing.T) {
+		ft := "e85"
+		count, err := fuelRepo.Count(ctx, FuelFilters{FuelType: &ft})
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+}

--- a/internal/repositories/maintenance_sqlite.go
+++ b/internal/repositories/maintenance_sqlite.go
@@ -223,7 +223,7 @@ func (r *SQLiteMaintenanceRepository) List(ctx context.Context, filters Maintena
 	args := []interface{}{}
 
 	if filters.VehicleID != nil {
-		query += " AND vehicle_id = ?"
+		query += sqlFilterVehicleID
 		args = append(args, *filters.VehicleID)
 	}
 
@@ -236,12 +236,12 @@ func (r *SQLiteMaintenanceRepository) List(ctx context.Context, filters Maintena
 
 	// Add pagination
 	if pagination.Limit > 0 {
-		query += " LIMIT ?"
+		query += sqlLimit
 		args = append(args, pagination.Limit)
 	}
 
 	if pagination.Offset > 0 {
-		query += " OFFSET ?"
+		query += sqlOffset
 		args = append(args, pagination.Offset)
 	}
 
@@ -260,7 +260,7 @@ func (r *SQLiteMaintenanceRepository) Count(ctx context.Context, filters Mainten
 	args := []interface{}{}
 
 	if filters.VehicleID != nil {
-		query += " AND vehicle_id = ?"
+		query += sqlFilterVehicleID
 		args = append(args, *filters.VehicleID)
 	}
 

--- a/internal/repositories/security_test.go
+++ b/internal/repositories/security_test.go
@@ -190,3 +190,65 @@ func TestSQLInjection_MaintenanceRepository(t *testing.T) {
 		}
 	})
 }
+
+// TestSQLInjection_FuelRepository verifies that parameterized queries protect
+// the fuel repository against SQL injection attacks.
+func TestSQLInjection_FuelRepository(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	userRepo := NewSQLiteUserRepository(db)
+	vehicleRepo := NewSQLiteVehicleRepository(db)
+	fuelRepo := NewSQLiteFuelRepository(db)
+	ctx := context.Background()
+
+	// Seed prerequisite data.
+	user := &models.User{
+		Username:     "fuelowner",
+		Email:        "fowner@example.com",
+		PasswordHash: "hashed_password",
+	}
+	require.NoError(t, userRepo.Create(ctx, user))
+
+	vehicle := &models.Vehicle{
+		UserID: user.ID,
+		VIN:    "3HGBH41JXMN109188",
+		Make:   "Ford",
+		Model:  "F-150",
+		Year:   2023,
+		Status: models.VehicleStatusActive,
+	}
+	require.NoError(t, vehicleRepo.Create(ctx, vehicle))
+
+	injectionPayloads := []string{
+		"' OR '1'='1",
+		"'; DROP TABLE fuel_records; --",
+		"' UNION SELECT * FROM fuel_records --",
+	}
+
+	t.Run("FindByID rejects SQL injection payloads", func(t *testing.T) {
+		for _, payload := range injectionPayloads {
+			result, err := fuelRepo.FindByID(ctx, payload)
+			assert.Nil(t, result, "payload %q should not return a record", payload)
+			assert.Error(t, err, "payload %q should produce an error", payload)
+		}
+	})
+
+	t.Run("FindByVehicleID rejects SQL injection payloads", func(t *testing.T) {
+		for _, payload := range injectionPayloads {
+			results, err := fuelRepo.FindByVehicleID(ctx, payload)
+			require.NoError(t, err, "parameterized query should not fail for payload %q", payload)
+			assert.Empty(t, results, "payload %q should not return records", payload)
+		}
+	})
+
+	t.Run("Delete with SQL injection payload does not affect data", func(t *testing.T) {
+		err := fuelRepo.Delete(ctx, "'; DROP TABLE fuel_records; --")
+		assert.Error(t, err, "should return not-found error")
+
+		// Verify we can still query the table
+		count, err := fuelRepo.Count(ctx, FuelFilters{})
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+}

--- a/internal/repositories/testutils_test.go
+++ b/internal/repositories/testutils_test.go
@@ -159,5 +159,41 @@ func runMigrations(db *sql.DB) error {
 		return err
 	}
 
+	// Create fuel_records table
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS fuel_records (
+			id TEXT PRIMARY KEY,
+			vehicle_id TEXT NOT NULL,
+			fill_date DATE NOT NULL,
+			mileage INTEGER NOT NULL,
+			volume REAL NOT NULL,
+			fuel_type TEXT NOT NULL DEFAULT 'gasoline' CHECK(fuel_type IN ('gasoline', 'diesel', 'e85')),
+			partial_fill INTEGER NOT NULL DEFAULT 0,
+			price_per_unit REAL,
+			octane_rating INTEGER,
+			location TEXT,
+			brand TEXT,
+			notes TEXT,
+			city_driving_percentage INTEGER CHECK(city_driving_percentage IS NULL OR (city_driving_percentage >= 0 AND city_driving_percentage <= 100)),
+			vehicle_reported_mpg REAL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (vehicle_id) REFERENCES vehicles(id) ON DELETE CASCADE
+		)
+	`)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_fuel_records_vehicle_id ON fuel_records(vehicle_id)`)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_fuel_records_fill_date ON fuel_records(fill_date)`)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/repositories/vehicle.go
+++ b/internal/repositories/vehicle.go
@@ -21,6 +21,13 @@ type PaginationParams struct {
 	Offset int
 }
 
+// Common SQL fragments used by multiple repositories
+const (
+	sqlFilterVehicleID = " AND vehicle_id = ?"
+	sqlLimit           = " LIMIT ?"
+	sqlOffset          = " OFFSET ?"
+)
+
 // VehicleRepository defines the interface for vehicle data access
 type VehicleRepository interface {
 	// Create inserts a new vehicle into the database

--- a/migrations/000007_create_fuel_records_table.down.sql
+++ b/migrations/000007_create_fuel_records_table.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_fuel_records_fill_date;
+DROP INDEX IF EXISTS idx_fuel_records_vehicle_id;
+DROP TABLE IF EXISTS fuel_records;

--- a/migrations/000007_create_fuel_records_table.up.sql
+++ b/migrations/000007_create_fuel_records_table.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS fuel_records (
+    id TEXT PRIMARY KEY,
+    vehicle_id TEXT NOT NULL,
+    fill_date DATE NOT NULL,
+    mileage INTEGER NOT NULL,
+    volume REAL NOT NULL,
+    fuel_type TEXT NOT NULL DEFAULT 'gasoline' CHECK(fuel_type IN ('gasoline', 'diesel', 'e85')),
+    partial_fill INTEGER NOT NULL DEFAULT 0,
+    price_per_unit REAL,
+    octane_rating INTEGER,
+    location TEXT,
+    brand TEXT,
+    notes TEXT,
+    city_driving_percentage INTEGER CHECK(city_driving_percentage IS NULL OR (city_driving_percentage >= 0 AND city_driving_percentage <= 100)),
+    vehicle_reported_mpg REAL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (vehicle_id) REFERENCES vehicles(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_fuel_records_vehicle_id ON fuel_records(vehicle_id);
+CREATE INDEX idx_fuel_records_fill_date ON fuel_records(fill_date);

--- a/spec/data-schema.md
+++ b/spec/data-schema.md
@@ -68,14 +68,17 @@ Stores fuel fill-up records for each vehicle.
 - id (primary key)
 - vehicle_id (foreign key to Vehicles)
 - fill_date (date and time of fill-up)
-- mileage (mileage at fill-up)
-- price (total price paid)
-- volume (gallons)
-- city_driving_percentage (0-100)
-- octane_rating
-- location
-- brand
-- notes
+- mileage (odometer at fill-up, required)
+- volume (gallons, required)
+- fuel_type (gasoline, diesel, e85; defaults to gasoline, required)
+- partial_fill (boolean, defaults false, required)
+- price_per_unit (price per gallon, optional)
+- octane_rating (optional)
+- location (optional)
+- brand (optional)
+- notes (optional)
+- city_driving_percentage (0-100, optional)
+- vehicle_reported_mpg (optional)
 - created_at, updated_at
 
 ## Relationships


### PR DESCRIPTION
## Summary

Add fuel fill-up tracking at the database, model, and repository layers. This implements the data layer for fuel records, following the same patterns established by maintenance records.

**Spec:** `spec/data-schema.md` (Fuel Records Table)

## Changes

### Database Migration (000007)
- `fuel_records` table with required fields (`fill_date`, `mileage`, `volume`, `fuel_type`, `partial_fill`) and optional fields (`price_per_unit`, `octane_rating`, `location`, `brand`, `notes`, `city_driving_percentage`, `vehicle_reported_mpg`)
- CHECK constraints on `fuel_type` enum (`gasoline`, `diesel`, `e85`) and `city_driving_percentage` (0–100)
- Indexes on `vehicle_id` and `fill_date`
- Foreign key to `vehicles` with `ON DELETE CASCADE`

### Model Layer
- `FuelType` string enum with display name helpers (`IsValidFuelType`, `FuelTypeDisplayName`, `AllFuelTypes`)
- `FuelRecord` struct — required fields as value types, optional fields as pointers
- `ValidateFuelRecord()` with 10 validation rules (vehicle_id, fill_date not future, mileage > 0, volume > 0, valid fuel_type, price_per_unit >= 0, octane_rating > 0, city_driving_percentage 0–100, vehicle_reported_mpg > 0)

### Repository Layer
- `FuelRepository` interface: `Create`, `FindByID`, `FindByVehicleID`, `Update`, `Delete`, `List`, `Count`
- `SQLiteFuelRepository` split into `fuel_sqlite.go` (write ops) and `fuel_sqlite_read.go` (read ops + scan helpers) per architecture file size guidelines
- Parameterized queries throughout; nullable fields handled via `sql.Null*` types

### Tests
- `fuel_test.go` — FuelType enum helper tests
- `validation_test.go` — 17 table-driven `ValidateFuelRecord` tests
- `fuel_sqlite_test.go` — Full CRUD repository tests with filter/pagination and nullable field round-trips
- `security_test.go` — SQL injection tests for fuel repository

### Documentation Updates
- `spec/data-schema.md` — Updated fuel_records field definitions
- `docs/database-schema.md` — Added fuel_records to ERD, table descriptions, relationships, migrations table
- `docs/database-migrations.md` — Added migrations 000006 and 000007
- `docs/repositories.md` — Added FuelRepository interface documentation
- `docs/validation.md` — Added fuel record validation rules

## Next Steps (not in this PR)
- FuelService business logic layer
- Vehicle Metrics integration for fuel spending
- API/Page handlers and web UI
- Seed data
- MPG computation between consecutive fill-ups

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [x] `make fmt` and `make vet` pass
- [x] Relevant spec/docs updated
- [x] PR description references the spec being addressed
